### PR TITLE
adds mobility table to personal info report

### DIFF
--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -636,3 +636,36 @@
   </tbody>
 </table>
 {% endmacro %}
+
+{% macro personalInfoMobility(rows) %}
+<table cellpadding="0" cellspacing="0" width="100%">
+  <thead>
+    <tr>
+      <th width="1">MOBILITY:</th>
+      <th width="1"></th>
+      <th width="1"></th>
+      <th width="1"></th>
+      <th width="1"></th>
+    </tr>
+    <tr>
+      <th width="1">School Code</th>
+      <th width="1">Entry Date</th>
+      <th width="1">Entry Code</th>
+      <th width="1">Exit Date</th>
+      <th width="1">Exit Code</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% set className = cycler("odd", "even") %}
+    {% for row in rows %}
+    <tr class="{{ className.next() }}">
+      <td>{{ "" }}</td>
+      <td>{{ "" }}</td>
+      <td>{{ "" }}</td>
+      <td>{{ "" }}</td>
+      <td>{{ "" }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endmacro %}

--- a/templates/personalinfo.njk
+++ b/templates/personalinfo.njk
@@ -110,7 +110,7 @@
     <div class="page" data-pageNum="1">
       <div class="no-break">
         <br />
-        {{macros.mobility([])}}
+        {{macros.personalInfoMobility([])}}
         <br />
         {{macros.personalInfoImmunizations([])}}
       </div>


### PR DESCRIPTION
We had a mobility table defined in macros already, but the mobility table on the personal info report is a lil different. This adds the personal info report specific mobility html table.