### PR TITLE
adds bldg_name to gates/reading to populate School: header when...

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -139,7 +139,7 @@ async function runReport(browser: Browser, student_number: number) {
       })
     )
 
-    // console.info('Rendering Personal Info HTML…')
+    // html personalinfo
     fs.writeFile(personalinfo_html_path, render('personalinfo.njk', {
       date: REPORT_DATE,
       student_personal_data_report,

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -197,7 +197,7 @@
 {% macro testTableHeader(row) %}
   {% set bldgName = row.BLDG_NAME %}
   {% set schoolName = row.SCHOOL_NAME %}
-  {% set displaySchoolName = row.SCHOOL_NAME if row.SCHOOL_NAME !== undefined else row.BLDG_NAME %}
+  {% set displaySchoolName = schoolName  if schoolName  !== undefined else bldgName %}
 
   <div id="header">
     <span class="testName">{{ row.TEST_NAME }}</span>

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -195,11 +195,15 @@
 {% endmacro %}
 
 {% macro testTableHeader(row) %}
+  {% set bldgName = row.BLDG_NAME %}
+  {% set schoolName = row.SCHOOL_NAME %}
+  {% set displaySchoolName = row.SCHOOL_NAME if row.SCHOOL_NAME !== undefined else row.BLDG_NAME %}
+
   <div id="header">
     <span class="testName">{{ row.TEST_NAME }}</span>
     Grade:<span class="testMetaAttr">{{ row.GRADE }}</span>
     Date:<span class="testMetaAttr">{{row.SORT_DATE | formatDate }}</span>
-    School:<span class="testMetaAttr">{{row.SCHOOL_NAME}}</span>
+    School:<span class="testMetaAttr">{{displaySchoolName}}</span>
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
The Gates Reading Test didn't contain a school_name attr, instead it's using bldg_name. This makes testTableHeader work for both school_name and bldg_name.