### PR TITLE
Adjust order of testscores tables. Add NAGLIERI table

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -953,6 +953,7 @@ export const queries = {
   explore,
   eoi,
   act,
+  nagle,
   studentPersonalDataReport,
   spd_Mobility,
   spd_Immunizations,

--- a/src/script.ts
+++ b/src/script.ts
@@ -88,6 +88,7 @@ async function runReport(browser: Browser, student_number: number) {
     const sta9 = await queries.sat9(student_number)
     const sat = await queries.sat(student_number)
     const itbs = await queries.itbs(student_number)
+    const nagle = await queries.nagle(student_number)
 
     const spd_mobility = await queries.spd_Mobility(student_number)
     const spd_immunizations = await queries.spd_Immunizations(student_number)
@@ -136,6 +137,7 @@ async function runReport(browser: Browser, student_number: number) {
         sta9,
         sat,
         itbs,
+        nagle
       })
     )
 

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -208,7 +208,7 @@
 {% endmacro %}
 
 {% macro testTableOtis(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -307,7 +307,7 @@
 {% endmacro %}
 
 {% macro testTableOklaCore(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -398,7 +398,7 @@
 {% endmacro %}
 
 {% macro testTableExplore(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -450,7 +450,7 @@
 {% endmacro %}
 
 {% macro testTableEndOfInstruction(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -490,7 +490,7 @@
 {% endmacro %}
 
 {% macro testTablePlan(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -553,7 +553,7 @@
 {% endmacro %}
 
 {% macro testTableAct(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -809,7 +809,7 @@
 {% endmacro %}
 
 {% macro testTableNAGL(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -919,7 +919,7 @@
 {% endmacro %}
 
 {% macro testTablePBP(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>
@@ -1021,7 +1021,7 @@
 {% endmacro %}
 
 {% macro testTableSAT(rows) %}
-  {% for row in rows %}
+  {% for row in rows|sort(attribute="SORT_DATE") %}
     {{ testTableHeader(row) }}
     <table cellpadding="0" cellspacing="0" width="100%">
       <thead>

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -766,7 +766,7 @@
   </tr>
 {% endmacro %}
 {% macro testTableITBS(rows) %}
-  {% for date, rows in rows | groupby("SORT_DATE") %}
+  {% for date, rows in rows|sort(attribute="SORT_DATE") | groupby("SORT_DATE") %}
 
     {% set header = rows[0] %}
     {{ testTableHeader(header) }}

--- a/templates/testscores.njk
+++ b/templates/testscores.njk
@@ -88,6 +88,12 @@
         {{ macros.testTableOtis(otis) }}
       </div>
       <div class="no-break">
+        {{ macros.testTableStanford9(sta9) }}
+      </div>
+      <div class="no-break">
+        {{ macros.testTableITBS(itbs) }}
+      </div>
+      <div class="no-break">
         {{ macros.testTableIowaTap(iowa_new) }}
       </div>
       <div class="no-break">
@@ -100,6 +106,12 @@
         {{ macros.testTableExplore(explore) }}
       </div>
       <div class="no-break">
+        {{ macros.testTableNAGL(nagle) }}
+      </div>
+      <div class="no-break">
+        {{ macros.testTablePBP(pbp) }}
+      </div>
+      <div class="no-break">
         {{ macros.testTableEndOfInstruction(eoi) }}
       </div>
       <div class="no-break">
@@ -109,19 +121,7 @@
         {{ macros.testTableAct(act) }}
       </div>
       <div class="no-break">
-        {{ macros.testTableITBS(itbs) }}
-      </div>
-      <div class="no-break">
-        {{ macros.testTablePBP(pbp) }}
-      </div>
-      <div class="no-break">
         {{ macros.testTableSAT(sat) }}
-      </div>
-      <div class="no-break">
-        {{ macros.testTableStanford9(sta9) }}
-      </div>
-      <div class="no-break">
-        {{ macros.testTableNAGL(nagle) }}
       </div>
     </div>
 


### PR DESCRIPTION
Changes the order that testscore tables appear. Adds back the nagle query. Sorts tables by SORT_DATE