### PR TITLE
prevents the testscore table headers from wrapping to a new line

### DIFF
--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -199,11 +199,11 @@
   {% set schoolName = row.SCHOOL_NAME %}
   {% set displaySchoolName = schoolName  if schoolName  !== undefined else bldgName %}
 
-  <div id="header">
-    <span class="testName">{{ row.TEST_NAME }}</span>
+  <div id="header" class="testTableHeader">
+    <span class="testName">{{ row.TEST_NAME|truncate(24,true,"") }}</span>
     Grade:<span class="testMetaAttr">{{ row.GRADE }}</span>
-    Date:<span class="testMetaAttr">{{row.SORT_DATE | formatDate }}</span>
-    School:<span class="testMetaAttr">{{displaySchoolName}}</span>
+    Date:<span class="testMetaAttr">{{ row.SORT_DATE | formatDate }}</span>
+    School:<span class="testMetaAttr">{{ displaySchoolName }}</span>
   </div>
 {% endmacro %}
 

--- a/templates/testscores.njk
+++ b/templates/testscores.njk
@@ -62,6 +62,10 @@
       .testMetaAttr {
         margin: 0 30px 0 10px;
       }
+      .testTableHeader {
+        overflow: hidden;
+        white-space: nowrap;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Screenshots

before
![image](https://user-images.githubusercontent.com/362647/224369775-1b36ab53-5d12-4ce9-bcc9-2c084cea6cc3.png)

after
![image](https://user-images.githubusercontent.com/362647/224369860-006e4655-cc01-4863-86ce-402ecaa750ea.png)
