### PR TITLE
addresses errors encountered thus far on big export

### DIFF
--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -727,7 +727,7 @@
     {% set className = cycler("odd", "even") %}
     {% for row in rows|sort(attribute="ENTRY_DATE") %}
     <tr class="{{ className.next() }}">
-      <td>{{ row.SCHOOL_CODE }} {{ row.BLDG_NAME|trim|truncate(12) }}</td>
+      <td>{{ row.SCHOOL_CODE }} {{ row.BLDG_NAME|trim|truncate(12) if row.BLDG_NAME|length }}</td>
       <td>{{ row.ENTRY_DATE | formatDate }}</td>
       <td>{{ row.ENTRY_TRANSFER_REASON_CODE }}</td>
       <td>{{ row.EXIT_DATE | formatDate }}</td>

--- a/templates/personalinfo.njk
+++ b/templates/personalinfo.njk
@@ -67,7 +67,7 @@
         <div class="date">Date: {{ date | formatDate }}</div>
       </div>
       <div class="student-name">
-        {{ student_personal_data_report.STUDENT_NAME | trim }},
+        {{ student_personal_data_report.STUDENT_NAME|trim if student_personal_data_report.STUDENT_NAME|length }},
       </div>
       <div id="subheader" style="display: flex; column-gap: 1rem;">
         <div style="flex-grow: 1; display: flex; flex-direction: column; row-gap: 0.5rem;">

--- a/templates/testscores.njk
+++ b/templates/testscores.njk
@@ -77,9 +77,9 @@
         <div class="date">Date: {{ date | formatDate }}</div>
       </div>
       <div class="student-name">
-        {{ student_data_transcript.STUDENT_LNAME | trim }},
-        {{ student_data_transcript.STUDENT_FNAME | trim }}
-        {{ student_data_transcript.STUDENT_MI | trim }}
+        {{ student_data_transcript.STUDENT_LNAME|trim if student_data_transcript.STUDENT_LNAME|length }},
+        {{ student_data_transcript.STUDENT_FNAME|trim if student_data_transcript.STUDENT_FNAME|length}}
+        {{ student_data_transcript.STUDENT_MI|trim if student_data_transcript.STUDENT_MI|length}}
       </div>
     </div>
 

--- a/templates/transcript.njk
+++ b/templates/transcript.njk
@@ -154,7 +154,11 @@
           Ranks {{ misc.RANK_STUD.replace(r/^0+/, '') if misc.RANK_STUD|length }} in class of {{ misc.RANK_CLASS.replace(r/^0+/, '') if misc.RANK_CLASS|length }}
         </div>
         <div style="flex-grow: 1;">
+          {% if misc.GRADUATION_DATE %}
           Graduation Date: {{ misc.GRADUATION_DATE.slice(0,2) }}-{{ misc.GRADUATION_DATE.slice(2,4) }}-{{ misc.GRADUATION_DATE.slice(4,6) }}
+          {% else %}
+          Graduation Date:
+          {% endif %}
         </div>
       </div>
 

--- a/templates/transcript.njk
+++ b/templates/transcript.njk
@@ -62,9 +62,9 @@
         <div class="date">Date: {{ date | formatDate }}</div>
       </div>
       <div class="student-name">
-        {{ student_data_transcript.STUDENT_LNAME | trim }},
-        {{ student_data_transcript.STUDENT_FNAME | trim }}
-        {{ student_data_transcript.STUDENT_MI | trim }}
+        {{ student_data_transcript.STUDENT_LNAME|trim if student_data_transcript.STUDENT_LNAME|length }},
+        {{ student_data_transcript.STUDENT_FNAME|trim if student_data_transcript.STUDENT_FNAME|length}}
+        {{ student_data_transcript.STUDENT_MI|trim if student_data_transcript.STUDENT_MI|length}}
       </div>
     </div>
 
@@ -104,13 +104,13 @@
           <div>
             Male:
             {% if demo.PARENT_LNAME %}
-              {{ demo.PARENT_LNAME | trim }}, {{ demo.PARENT_FNAME }} {{ demo.PARENT_MI }}
+              {{ demo.PARENT_LNAME|trim if demo.PARENT_LNAME|length }}, {{ demo.PARENT_FNAME }} {{ demo.PARENT_MI }}
             {% endif %}
           </div>
           <div>
             Female:
             {% if demo.SPARENT_LNAME %}
-              {{ demo.SPARENT_LNAME | trim }}, {{ demo.SPARENT_FNAME }} {{ demo.SPARENT_MI }}
+              {{ demo.SPARENT_LNAME|trim if demo.SPARENT_LNAME|length }}, {{ demo.SPARENT_FNAME }} {{ demo.SPARENT_MI }}
             {% endif %}
           </div>
 
@@ -151,7 +151,7 @@
 
       <div style="display: flex; column-gap: 1rem; margin: 1rem 0; text-align: center; font-weight: bold;">
         <div style="flex-grow: 1;">
-          Ranks {{ misc.RANK_STUD.replace(r/^0+/, '') }} in class of {{ misc.RANK_CLASS.replace(r/^0+/, '') }}
+          Ranks {{ misc.RANK_STUD.replace(r/^0+/, '') if misc.RANK_STUD|length }} in class of {{ misc.RANK_CLASS.replace(r/^0+/, '') if misc.RANK_CLASS|length }}
         </div>
         <div style="flex-grow: 1;">
           Graduation Date: {{ misc.GRADUATION_DATE.slice(0,2) }}-{{ misc.GRADUATION_DATE.slice(2,4) }}-{{ misc.GRADUATION_DATE.slice(4,6) }}


### PR DESCRIPTION
Using trim, slice, truncate, etc inside njk files causes an error when a null is encountered. This adds conditional logic to avoid the nulls